### PR TITLE
Propose API for a clean shutdown if the updater config provides handler

### DIFF
--- a/restart.go
+++ b/restart.go
@@ -7,7 +7,10 @@ import (
 	"github.com/fynelabs/selfupdate/internal/osext"
 )
 
-func Restart() error {
+// Restart will attempt to restar the current application, any error will be returned.
+// If the exiter function is passed in it will be responsible for terminating the old processes.
+// If exiter is passed an error it can assume the restart failed and handle appropriately.
+func Restart(exiter func(error)) error {
 	wd, err := os.Getwd()
 	if err != nil {
 		return err
@@ -24,5 +27,11 @@ func Restart() error {
 		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
 		Sys:   &syscall.SysProcAttr{},
 	})
+
+	if exiter != nil {
+		exiter(err)
+	} else if err == nil {
+		os.Exit(0)
+	}
 	return err
 }

--- a/updater.go
+++ b/updater.go
@@ -23,6 +23,7 @@ type Config struct {
 	ProgressCallback       func(float64, error) // if present will call back with 0.0 at the start, rising through to 1.0 at the end if the progress is known. A negative start number will be sent if size is unknown, any error will pass as is and the process is considered done
 	RestartConfirmCallback func() bool          // if present will ask for user acceptance before restarting app
 	UpgradeConfirmCallback func(string) bool    // if present will ask for user acceptance, it can present the message passed
+	ExitCallback           func(error)          // if present will be expected to handle app exit procedure
 }
 
 type Schedule struct {
@@ -83,7 +84,7 @@ func (u *Updater) CheckNow() error {
 }
 
 func (u *Updater) Restart() error {
-	return Restart()
+	return Restart(u.conf.ExitCallback)
 }
 
 // Manage sets up an Updater and runs it to manage the current executable.


### PR DESCRIPTION
A way to override with a clean shutdown. Or do `os.Exit(0)` if not provided