### PR TITLE
Public export of `getExecutableRealPath` and refactoring loading the exe path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Update coverage
       run: |
-        GO111MODULE=off go get github.com/mattn/goveralls
+        go get github.com/mattn/goveralls
         set -e
         go test -tags ci -covermode=atomic -coverprofile=coverage.out ./...
       if: ${{ runner.os == 'Linux' }}

--- a/apply.go
+++ b/apply.go
@@ -277,7 +277,7 @@ func (o *Options) SetPublicKeyPEM(pembytes []byte) error {
 
 func (o *Options) getPath() (string, error) {
 	if o.TargetPath == "" {
-		return getExecutableRealPath()
+		return GetExecutableRealPath()
 	}
 	return o.TargetPath, nil
 }

--- a/apply.go
+++ b/apply.go
@@ -76,10 +76,12 @@ func apply(update io.Reader, opts *Options) error {
 
 	// get target path
 	var err error
-	opts.TargetPath, err = opts.getPath()
+	err = LoadPath()
 	if err != nil {
 		return err
 	}
+	// ignore err since handled after LoadPath
+	opts.TargetPath, _ = opts.getPath()
 
 	var newBytes []byte
 	if opts.Patcher != nil {
@@ -106,12 +108,9 @@ func apply(update io.Reader, opts *Options) error {
 		}
 	}
 
-	// get the directory the executable exists in
-	updateDir := filepath.Dir(opts.TargetPath)
-	filename := filepath.Base(opts.TargetPath)
-
 	// Copy the contents of newbinary to a new executable file
-	newPath := filepath.Join(updateDir, fmt.Sprintf(".%s.new", filename))
+	// ignore err since handled after LoadPath
+	newPath, _ := GetExecutableNewPath()
 	fp, err := openFile(newPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, opts.TargetMode)
 	if err != nil {
 		return err
@@ -133,7 +132,8 @@ func apply(update io.Reader, opts *Options) error {
 	oldPath := opts.OldSavePath
 	removeOld := opts.OldSavePath == ""
 	if removeOld {
-		oldPath = filepath.Join(updateDir, fmt.Sprintf(".%s.old", filename))
+		// ignore err since handled after LoadPath
+		oldPath, _ = GetExecutableDefaultOldPath()
 	}
 
 	// delete any existing old exec file - this is necessary on Windows for two reasons:

--- a/apply.go
+++ b/apply.go
@@ -110,7 +110,7 @@ func apply(update io.Reader, opts *Options) error {
 
 	// Copy the contents of newbinary to a new executable file
 	// ignore err since handled after LoadPath
-	newPath, _ := GetExecutableNewPath()
+	newPath, _ := ExecutableNewPath()
 	fp, err := openFile(newPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, opts.TargetMode)
 	if err != nil {
 		return err
@@ -133,7 +133,7 @@ func apply(update io.Reader, opts *Options) error {
 	removeOld := opts.OldSavePath == ""
 	if removeOld {
 		// ignore err since handled after LoadPath
-		oldPath, _ = GetExecutableDefaultOldPath()
+		oldPath, _ = ExecutableDefaultOldPath()
 	}
 
 	// delete any existing old exec file - this is necessary on Windows for two reasons:
@@ -277,7 +277,7 @@ func (o *Options) SetPublicKeyPEM(pembytes []byte) error {
 
 func (o *Options) getPath() (string, error) {
 	if o.TargetPath == "" {
-		return GetExecutableRealPath()
+		return ExecutableRealPath()
 	}
 	return o.TargetPath, nil
 }

--- a/executable.go
+++ b/executable.go
@@ -18,6 +18,7 @@ var (
 	once              sync.Once
 )
 
+// ExecutableRealPath returns the path to the original executable and an error if something went bad
 func ExecutableRealPath() (string, error) {
 	if LoadPath() != nil {
 		return "", exeErr
@@ -25,6 +26,7 @@ func ExecutableRealPath() (string, error) {
 	return exePath, nil
 }
 
+// ExecutableDefaultOldPath returns the path to the old executable and an error if something went bad
 func ExecutableDefaultOldPath() (string, error) {
 	if LoadPath() != nil {
 		return "", exeErr
@@ -32,6 +34,7 @@ func ExecutableDefaultOldPath() (string, error) {
 	return defaultOldExePath, nil
 }
 
+// ExecutableNewPath returns the path to the new executable and an error if something went bad
 func ExecutableNewPath() (string, error) {
 	if LoadPath() != nil {
 		return "", exeErr
@@ -39,6 +42,8 @@ func ExecutableNewPath() (string, error) {
 	return newExePath, nil
 }
 
+// LoadPath loads the paths to the old, the current and the new executables,
+// it returns an error if something went bad
 func LoadPath() error {
 	once.Do(func() {
 		exePath, defaultOldExePath, newExePath, exeErr = loadPath()

--- a/executable.go
+++ b/executable.go
@@ -9,7 +9,7 @@ import (
 )
 
 func lastModifiedExecutable() (time.Time, error) {
-	exe, err := getExecutableRealPath()
+	exe, err := GetExecutableRealPath()
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -22,7 +22,7 @@ func lastModifiedExecutable() (time.Time, error) {
 	return fi.ModTime(), nil
 }
 
-func getExecutableRealPath() (string, error) {
+func GetExecutableRealPath() (string, error) {
 	exe, err := osext.Executable()
 	if err != nil {
 		return "", err

--- a/executable.go
+++ b/executable.go
@@ -1,12 +1,65 @@
 package selfupdate
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/fynelabs/selfupdate/internal/osext"
 )
+
+var (
+	exePath           string
+	defaultOldExePath string
+	newExePath        string
+	exeErr            error
+	once              sync.Once
+)
+
+func GetExecutableRealPath() (string, error) {
+	if LoadPath() != nil {
+		return "", exeErr
+	}
+	return exePath, nil
+}
+
+func GetExecutableDefaultOldPath() (string, error) {
+	if LoadPath() != nil {
+		return "", exeErr
+	}
+	return defaultOldExePath, nil
+}
+
+func GetExecutableNewPath() (string, error) {
+	if LoadPath() != nil {
+		return "", exeErr
+	}
+	return newExePath, nil
+}
+
+func LoadPath() error {
+	once.Do(func() {
+		exePath, defaultOldExePath, newExePath, exeErr = loadPath()
+	})
+	return exeErr
+}
+
+func loadPath() (string, string, string, error) {
+	exePath, err := getExecutableRealPath()
+	if err != nil {
+		return "", "", "", err
+	}
+	// get the directory the executable exists in
+	updateDir := filepath.Dir(exePath)
+	filename := filepath.Base(exePath)
+
+	// Copy the contents of newbinary to a new executable file
+	newPath := filepath.Join(updateDir, fmt.Sprintf(".%s.new", filename))
+	oldPath := filepath.Join(updateDir, fmt.Sprintf(".%s.old", filename))
+	return exePath, oldPath, newPath, nil
+}
 
 func lastModifiedExecutable() (time.Time, error) {
 	exe, err := GetExecutableRealPath()
@@ -22,7 +75,7 @@ func lastModifiedExecutable() (time.Time, error) {
 	return fi.ModTime(), nil
 }
 
-func GetExecutableRealPath() (string, error) {
+func getExecutableRealPath() (string, error) {
 	exe, err := osext.Executable()
 	if err != nil {
 		return "", err

--- a/executable.go
+++ b/executable.go
@@ -18,21 +18,21 @@ var (
 	once              sync.Once
 )
 
-func GetExecutableRealPath() (string, error) {
+func ExecutableRealPath() (string, error) {
 	if LoadPath() != nil {
 		return "", exeErr
 	}
 	return exePath, nil
 }
 
-func GetExecutableDefaultOldPath() (string, error) {
+func ExecutableDefaultOldPath() (string, error) {
 	if LoadPath() != nil {
 		return "", exeErr
 	}
 	return defaultOldExePath, nil
 }
 
-func GetExecutableNewPath() (string, error) {
+func ExecutableNewPath() (string, error) {
 	if LoadPath() != nil {
 		return "", exeErr
 	}
@@ -62,7 +62,7 @@ func loadPath() (string, string, string, error) {
 }
 
 func lastModifiedExecutable() (time.Time, error) {
-	exe, err := GetExecutableRealPath()
+	exe, err := ExecutableRealPath()
 	if err != nil {
 		return time.Time{}, err
 	}

--- a/executable.go
+++ b/executable.go
@@ -55,7 +55,7 @@ func loadPath() (string, string, string, error) {
 	updateDir := filepath.Dir(exePath)
 	filename := filepath.Base(exePath)
 
-	// Copy the contents of newbinary to a new executable file
+	// get file paths to new and old executable file paths
 	newPath := filepath.Join(updateDir, fmt.Sprintf(".%s.new", filename))
 	oldPath := filepath.Join(updateDir, fmt.Sprintf(".%s.old", filename))
 	return exePath, oldPath, newPath, nil

--- a/executable_test.go
+++ b/executable_test.go
@@ -15,7 +15,7 @@ func TestAlwaysFindExecutableTime(t *testing.T) {
 }
 
 func TestAlwaysFindExecutable(t *testing.T) {
-	exe, err := GetExecutableRealPath()
+	exe, err := ExecutableRealPath()
 	ext := filepath.Ext(exe)
 	assert.Nil(t, err)
 	assert.NotEmpty(t, exe)
@@ -27,7 +27,7 @@ func TestAlwaysFindExecutable(t *testing.T) {
 }
 
 func TestAlwaysFindOldExecutable(t *testing.T) {
-	exe, err := GetExecutableDefaultOldPath()
+	exe, err := ExecutableDefaultOldPath()
 	ext := filepath.Ext(exe)
 	assert.Nil(t, err)
 	assert.NotEmpty(t, exe)
@@ -35,7 +35,7 @@ func TestAlwaysFindOldExecutable(t *testing.T) {
 }
 
 func TestAlwaysFindNewExecutable(t *testing.T) {
-	exe, err := GetExecutableNewPath()
+	exe, err := ExecutableNewPath()
 	ext := filepath.Ext(exe)
 	assert.Nil(t, err)
 	assert.NotEmpty(t, exe)

--- a/executable_test.go
+++ b/executable_test.go
@@ -1,6 +1,9 @@
 package selfupdate
 
 import (
+	"fmt"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +16,28 @@ func TestAlwaysFindExecutableTime(t *testing.T) {
 
 func TestAlwaysFindExecutable(t *testing.T) {
 	exe, err := GetExecutableRealPath()
+	ext := filepath.Ext(exe)
 	assert.Nil(t, err)
 	assert.NotEmpty(t, exe)
+	if runtime.GOOS == "windows" {
+		assert.Equal(t, ".exe", ext)
+	} else {
+		assert.True(t, ext == ".test" || ext == "", fmt.Sprintf("Linux extesion not correct, got '%s'", ext))
+	}
+}
+
+func TestAlwaysFindOldExecutable(t *testing.T) {
+	exe, err := GetExecutableDefaultOldPath()
+	ext := filepath.Ext(exe)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, exe)
+	assert.Equal(t, ".old", ext)
+}
+
+func TestAlwaysFindNewExecutable(t *testing.T) {
+	exe, err := GetExecutableNewPath()
+	ext := filepath.Ext(exe)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, exe)
+	assert.Equal(t, ".new", ext)
 }

--- a/executable_test.go
+++ b/executable_test.go
@@ -12,7 +12,7 @@ func TestAlwaysFindExecutableTime(t *testing.T) {
 }
 
 func TestAlwaysFindExecutable(t *testing.T) {
-	exe, err := getExecutableRealPath()
+	exe, err := GetExecutableRealPath()
 	assert.Nil(t, err)
 	assert.NotEmpty(t, exe)
 }

--- a/http_source.go
+++ b/http_source.go
@@ -128,7 +128,7 @@ func replaceURLTemplate(base string) string {
 		Ext:  ext,
 	}
 
-	exe, err := getExecutableRealPath()
+	exe, err := GetExecutableRealPath()
 	if err != nil {
 		exe = filepath.Base(os.Args[0])
 	} else {

--- a/http_source.go
+++ b/http_source.go
@@ -128,7 +128,7 @@ func replaceURLTemplate(base string) string {
 		Ext:  ext,
 	}
 
-	exe, err := GetExecutableRealPath()
+	exe, err := ExecutableRealPath()
 	if err != nil {
 		exe = filepath.Base(os.Args[0])
 	} else {


### PR DESCRIPTION
Export to the public the call to `getExecutableRealPath` since it can be usefull,
also added the sibling calls `GetExecutableDefaultOldPath` and `GetExecutableNewPath`.

The function `LoadPath` is `sync.Once` to limit performance related issues