### PR TITLE
fix apply regression and made LoadPath private

### DIFF
--- a/executable.go
+++ b/executable.go
@@ -13,14 +13,13 @@ import (
 var (
 	exePath           string
 	defaultOldExePath string
-	newExePath        string
 	exeErr            error
 	once              sync.Once
 )
 
 // ExecutableRealPath returns the path to the original executable and an error if something went bad
 func ExecutableRealPath() (string, error) {
-	if LoadPath() != nil {
+	if loadPath() != nil {
 		return "", exeErr
 	}
 	return exePath, nil
@@ -28,42 +27,26 @@ func ExecutableRealPath() (string, error) {
 
 // ExecutableDefaultOldPath returns the path to the old executable and an error if something went bad
 func ExecutableDefaultOldPath() (string, error) {
-	if LoadPath() != nil {
+	if loadPath() != nil {
 		return "", exeErr
 	}
 	return defaultOldExePath, nil
 }
 
-// ExecutableNewPath returns the path to the new executable and an error if something went bad
-func ExecutableNewPath() (string, error) {
-	if LoadPath() != nil {
-		return "", exeErr
-	}
-	return newExePath, nil
-}
-
-// LoadPath loads the paths to the old, the current and the new executables,
-// it returns an error if something went bad
-func LoadPath() error {
+func loadPath() error {
 	once.Do(func() {
-		exePath, defaultOldExePath, newExePath, exeErr = loadPath()
+		exePath, exeErr = getExecutableRealPath()
+		if exeErr != nil {
+			return
+		}
+		// get the directory the executable exists in
+		updateDir := filepath.Dir(exePath)
+		filename := filepath.Base(exePath)
+
+		// get file path to the old executable
+		defaultOldExePath = filepath.Join(updateDir, fmt.Sprintf(".%s.old", filename))
 	})
 	return exeErr
-}
-
-func loadPath() (string, string, string, error) {
-	exePath, err := getExecutableRealPath()
-	if err != nil {
-		return "", "", "", err
-	}
-	// get the directory the executable exists in
-	updateDir := filepath.Dir(exePath)
-	filename := filepath.Base(exePath)
-
-	// get file paths to new and old executable file paths
-	newPath := filepath.Join(updateDir, fmt.Sprintf(".%s.new", filename))
-	oldPath := filepath.Join(updateDir, fmt.Sprintf(".%s.old", filename))
-	return exePath, oldPath, newPath, nil
 }
 
 func lastModifiedExecutable() (time.Time, error) {

--- a/executable_test.go
+++ b/executable_test.go
@@ -33,11 +33,3 @@ func TestAlwaysFindOldExecutable(t *testing.T) {
 	assert.NotEmpty(t, exe)
 	assert.Equal(t, ".old", ext)
 }
-
-func TestAlwaysFindNewExecutable(t *testing.T) {
-	exe, err := ExecutableNewPath()
-	ext := filepath.Ext(exe)
-	assert.Nil(t, err)
-	assert.NotEmpty(t, exe)
-	assert.Equal(t, ".new", ext)
-}


### PR DESCRIPTION
fix regression added in #34 in `selfupdate.apply` the custom `opts.TargetPath` was ignored when setting `newPath` and `oldPath`,
reverted all changes to `selfupdate.apply` in commit dfea30c7d63d7d44973618c1c481242e3d1fca0b.

`LoadPath` is now private and `ExecutableNewPath` got removed.

Sorry for the trouble!
